### PR TITLE
bugfix: fix ormconfig database from 'mysql' to 'guardian'

### DIFF
--- a/ormconfig.example.json
+++ b/ormconfig.example.json
@@ -4,7 +4,7 @@
    "port": 3306,
    "username": "root",
    "password": "",
-   "database": "mysql",
+   "database": "guardian",
    "synchronize": true,
    "logging": false,
    "entities": [


### PR DESCRIPTION
This PR fixes `ormconfig.example.json`'s `database` field from `mysql` to `guardian`, since the intended database for use in this application was `guardian`.