### PR TITLE
Add path typing annotations + Use undefined instead of null in SingleUserReadReesponse

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -32,7 +32,7 @@ interface UserModificationRequestBody {
  * Response containing requested user information
  */
 interface SingleUserReadResponse {
-    user: IUser | null;
+    user?: IUser;
 }
 
 /**
@@ -75,6 +75,7 @@ export class UserController extends Controller {
      *
      * @param id the user's identifier
      * @example id 4
+     * @isInt id
      */
     @Example<SingleUserReadResponse>({
         user: {
@@ -82,7 +83,7 @@ export class UserController extends Controller {
             nickname: 'max'
         }
     })
-    @Response<SingleUserReadResponse>(404, 'Resource Not Found', { user: null })
+    @Response<SingleUserReadResponse>(404, 'Resource Not Found', {})
     @Get('{id}')
     async getUser(@Path() id: number): Promise<SingleUserReadResponse> {
         const user = await UserService.getSingleUser(id);
@@ -114,8 +115,10 @@ export class UserController extends Controller {
      * Currently, a user only has a nickname as information.
      *
      * @param id the user's identifier
-     * @param requestBody json object that contains the user's desired new nickname
      * @example id 2
+     * @isInt id
+     *
+     * @param requestBody json object that contains the user's desired new nickname
      * @example requestBody { "nickname": "foo" }
      */
     @Response<SuccessStatusResponse>(404, 'Resource Not Found', {
@@ -141,6 +144,7 @@ export class UserController extends Controller {
      *
      * @param id the user's identifier
      * @example id 2
+     * @isInt id
      */
     @Delete('{id}')
     @Response<SuccessStatusResponse>(404, 'Resource Not Found', {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -21,7 +21,7 @@ const models: TsoaRoute.Models = {
     "SingleUserReadResponse": {
         "dataType": "refObject",
         "properties": {
-            "user": {"dataType":"union","subSchemas":[{"ref":"IUser"},{"dataType":"enum","enums":[null]}],"required":true},
+            "user": {"ref":"IUser"},
         },
         "additionalProperties": false,
     },
@@ -84,7 +84,7 @@ export function RegisterRoutes(app: express.Router) {
         app.get('/api/user/:id',
             function (request: any, response: any, next: any) {
             const args = {
-                    id: {"in":"path","name":"id","required":true,"dataType":"double"},
+                    id: {"in":"path","name":"id","required":true,"dataType":"integer","validators":{"isInt":{"errorMsg":"id"}}},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -129,7 +129,7 @@ export function RegisterRoutes(app: express.Router) {
             function (request: any, response: any, next: any) {
             const args = {
                     requestBody: {"in":"body","name":"requestBody","required":true,"ref":"UserModificationRequestBody"},
-                    id: {"in":"path","name":"id","required":true,"dataType":"double"},
+                    id: {"in":"path","name":"id","required":true,"dataType":"integer","validators":{"isInt":{"errorMsg":"id"}}},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -151,7 +151,7 @@ export function RegisterRoutes(app: express.Router) {
         app.delete('/api/user/:id',
             function (request: any, response: any, next: any) {
             const args = {
-                    id: {"in":"path","name":"id","required":true,"dataType":"double"},
+                    id: {"in":"path","name":"id","required":true,"dataType":"integer","validators":{"isInt":{"errorMsg":"id"}}},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -8,13 +8,12 @@ const getAll = async (): Promise<User[]> => {
     });
 };
 
-const getSingleUser = async (id: number): Promise<User | null> => {
+const getSingleUser = async (id: number): Promise<User | undefined> => {
     const user = await getRepository(User).findOne({
         select: ['id', 'nickname'],
         where: { id, deleted: 0 }
     });
 
-    if (!user) return null;
     return user;
 };
 

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -72,6 +72,6 @@ describe('/api/user endpoint test', () => {
     it('should not retreive information of a deleted user "baz"', async () => {
         const response = await request(app).get('/api/user/1');
         expect(response.status).toBe(404);
-        expect(response.body.user).toBeNull();
+        expect(response.body.user).toBeUndefined();
     });
 });


### PR DESCRIPTION
This PR updates the `SingleUserReadResponse` type info and integer annotations for path ids.
As a result, the `user` field in `SingleUserReadResponse` now has a chance to be `undefined` when a user is not in a service. Such choice has been made because setting `SingleUserReadResponse` as a `{ user: IUser | null }` type somehow causes swagger to generate a failed response as an empty object (`{}`) instead of the originally intended `{ user: null }`.